### PR TITLE
Success event handlers: ownActions

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,10 +393,17 @@ function* onOrderSuccess({ requestData: order }) {
 }
 ```
 
-An onSuccess handler will always receive as parameter an object containing the keys `requestData`
-and `responseData`. The value of `requestData` is the parameter passed when calling the
-actionCreator `load`, `create`, `update` or `remove`. The value of `responseData` is the return
-value of the api method.
+An onSuccess handler will always receive as first parameter an object containing the keys
+`requestData` and `responseData` (it also receives an `id` if it's a
+[dynamic resource](#dynamic-resources)). The value of `requestData` is the parameter passed when
+calling the actionCreator `load`, `create`, `update` or `remove`. The value of `responseData` is the
+return value of the api method.
+
+The second parameter received by a success handler is the object `ownActions`, this object is the
+same received in `actions` when calling `createResources`. It's useful when you need to perform an
+action on the same resource when something succeeds, e.g. you could to update the `data` of a
+resource with the payload of the operation `update`. In this case, you'd call
+`ownActions.setLoadSuccess(responseData)`.
 
 # Utilities for checking the operation status
 
@@ -573,6 +580,7 @@ A dynamic resource works almost exactly like a common resource. The only differe
 - Every api method receives the id as its first parameter and a data object as second parameter;
 - Every action creator must receive an id as its first parameter. `load`, for instance must be
 passed an id.
+- A success handler will also receive the property `id` in the object passed as first parameter.
 - The redux state is no longer a resource. Instead, it is an object where every key is an id and
 its value is a resource.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zup-next/redux-resource",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Utilities for creating CRUD resources for redux",
   "main": "lib/redux-resource.js",
   "types": "lib",

--- a/src/__tests__/sagas/dynamic.spec.ts
+++ b/src/__tests__/sagas/dynamic.spec.ts
@@ -58,7 +58,7 @@ describe('Saga', () => {
     expect(saga.next().value).toEqual(call(api[operation], id, data))
     expect(saga.next(response).value).toEqual(put(setSuccess(id)))
     saga.next()
-    expect(onSuccess[operation]).toHaveBeenCalledWith({ id, requestData: data, responseData: response })
+    expect(onSuccess[operation]).toHaveBeenCalledWith({ id, requestData: data, responseData: response }, actions)
     expect(saga.next().done).toBeTruthy()
   }
 
@@ -103,7 +103,7 @@ describe('Saga', () => {
     expect(saga.next().value).toEqual(call(api.load, id, params))
     expect(saga.next(response).value).toEqual(put(setLoadSuccess(id, response)))
     saga.next()
-    expect(onSuccess.load).toHaveBeenCalledWith({ id, requestData: params, responseData: response })
+    expect(onSuccess.load).toHaveBeenCalledWith({ id, requestData: params, responseData: response }, actions)
     expect(saga.next().done).toBeTruthy()
   })
 

--- a/src/__tests__/sagas/static.spec.ts
+++ b/src/__tests__/sagas/static.spec.ts
@@ -57,7 +57,7 @@ describe('Saga', () => {
     expect(saga.next().value).toEqual(call(api[operation], data))
     expect(saga.next(response).value).toEqual(put(setSuccess()))
     saga.next()
-    expect(onSuccess[operation]).toHaveBeenCalledWith({ requestData: data, responseData: response })
+    expect(onSuccess[operation]).toHaveBeenCalledWith({ requestData: data, responseData: response }, actions)
     expect(saga.next().done).toBeTruthy()
   }
 
@@ -100,7 +100,7 @@ describe('Saga', () => {
     expect(saga.next().value).toEqual(call(api.load, params))
     expect(saga.next(response).value).toEqual(put(setLoadSuccess(response)))
     saga.next()
-    expect(onSuccess.load).toHaveBeenCalledWith({ requestData: params, responseData: response })
+    expect(onSuccess.load).toHaveBeenCalledWith({ requestData: params, responseData: response }, actions)
     expect(saga.next().done).toBeTruthy()
   })
 

--- a/src/sagas/dynamic.ts
+++ b/src/sagas/dynamic.ts
@@ -11,6 +11,7 @@ import { call, put } from 'redux-saga/effects'
 import { createMissingSagaWarning } from './utils'
 
 interface ModifyResource {
+  actions: DynamicResourceActions,
   setPending: (id: string) => DynamicAction,
   setSuccess: (id: string) => DynamicAction,
   setError: (id: string, error: any) => DynamicAction,
@@ -29,7 +30,7 @@ const loadResource = (
       yield put(setLoadPending(id))
       const data = yield call(load, id, params)
       yield put(setLoadSuccess(id, data))
-      if (onSuccess) yield onSuccess({ id, requestData: params, responseData: data })
+      if (onSuccess) yield onSuccess({ id, requestData: params, responseData: data }, actions)
     } catch (error) {
       yield put(setLoadError(id, error))
     }
@@ -37,14 +38,14 @@ const loadResource = (
 }
 
 const modifyResource = (props: ModifyResource) => {
-  const { setPending, setSuccess, setError, execute, onSuccess } = props
+  const { actions, setPending, setSuccess, setError, execute, onSuccess } = props
 
   return function* ({ id, data }: DynamicAction) {
     try {
       yield put(setPending(id))
       const response = yield call(execute, id, data)
       yield put(setSuccess(id))
-      if (onSuccess) yield onSuccess({ id, requestData: data, responseData: response })
+      if (onSuccess) yield onSuccess({ id, requestData: data, responseData: response }, actions)
     } catch (error) {
       yield put(setError(id, error))
     }
@@ -64,6 +65,7 @@ const createDynamicResourceSagas = (
 
   if (api.create) {
     const createSaga = modifyResource({
+      actions,
       setPending: actions.setCreatePending,
       setSuccess: actions.setCreateSuccess,
       setError: actions.setCreateError,
@@ -78,6 +80,7 @@ const createDynamicResourceSagas = (
 
   if (api.update) {
     const updateSaga = modifyResource({
+      actions,
       setPending: actions.setUpdatePending,
       setSuccess: actions.setUpdateSuccess,
       setError: actions.setUpdateError,
@@ -92,6 +95,7 @@ const createDynamicResourceSagas = (
 
   if (api.remove) {
     const removeSaga = modifyResource({
+      actions,
       setPending: actions.setRemovePending,
       setSuccess: actions.setRemoveSuccess,
       setError: actions.setRemoveError,

--- a/src/sagas/static.ts
+++ b/src/sagas/static.ts
@@ -11,6 +11,7 @@ import { call, put } from 'redux-saga/effects'
 import { createMissingSagaWarning } from './utils'
 
 interface ModifyResource {
+  actions: ResourceActions,
   setPending: () => Action,
   setSuccess: () => Action,
   setError: (error: any) => Action,
@@ -29,7 +30,7 @@ export const loadResource = (
       yield put(setLoadPending())
       const data = yield call(load, params)
       yield put(setLoadSuccess(data))
-      if (onSuccess) yield onSuccess({ requestData: params, responseData: data })
+      if (onSuccess) yield onSuccess({ requestData: params, responseData: data }, actions)
     } catch (error) {
       yield put(setLoadError(error))
     }
@@ -37,14 +38,14 @@ export const loadResource = (
 }
 
 export const modifyResource = (props: ModifyResource) => {
-  const { setPending, setSuccess, setError, execute, onSuccess } = props
+  const { actions, setPending, setSuccess, setError, execute, onSuccess } = props
 
   return function* ({ data }: Action) {
     try {
       yield put(setPending())
       const response = yield call(execute, data)
       yield put(setSuccess())
-      if (onSuccess) yield onSuccess({ requestData: data, responseData: response })
+      if (onSuccess) yield onSuccess({ requestData: data, responseData: response }, actions)
     } catch (error) {
       yield put(setError(error))
     }
@@ -64,6 +65,7 @@ const createResourceSagas = (
 
   if (api.create) {
     const createSaga = modifyResource({
+      actions,
       setPending: actions.setCreatePending,
       setSuccess: actions.setCreateSuccess,
       setError: actions.setCreateError,
@@ -78,6 +80,7 @@ const createResourceSagas = (
 
   if (api.update) {
     const updateSaga = modifyResource({
+      actions,
       setPending: actions.setUpdatePending,
       setSuccess: actions.setUpdateSuccess,
       setError: actions.setUpdateError,
@@ -92,6 +95,7 @@ const createResourceSagas = (
 
   if (api.remove) {
     const removeSaga = modifyResource({
+      actions,
       setPending: actions.setRemovePending,
       setSuccess: actions.setRemoveSuccess,
       setError: actions.setRemoveError,

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,10 +7,15 @@ export enum Status {
 
 export type Operation = 'load' | 'create' | 'update' | 'remove'
 
-export type SagaEventHandler = (data: { requestData?: any, responseData: any }) => void
+export type SagaEventHandler = (
+  data: { requestData?: any, responseData: any },
+  ownActions: ResourceActions,
+) => void
 
-export type DynamicSagaEventHandler =
-  (data: { id: string, requestData?: any, responseData: any }) => void
+export type DynamicSagaEventHandler = (
+  data: { id: string, requestData?: any, responseData: any },
+  ownActions: DynamicResourceActions,
+) => void
 
 export interface ResourceOperation {
   status: Status,


### PR DESCRIPTION
Ao criar um recurso, é possível especificar os "success handlers". "success handlers" são sagas que rodam após o sucesso de uma operação.

Atualmente, os handlers recebem apenas um parâmetro data que contém o payload da requisição e o payload da resposta. Este PR adiciona mais um parâmetro que são as "ownActions".

"ownActions" é uma referência para os action creators do próprio recurso. Foi implementado para os casos onde seria útil disparar tais ações. Por exemplo: fazer com que o resultado da operação "update" atualize o campo "data":

```javascript
function* onUpdateSuccess({ responseData }, ownActions) {
  yield put(ownActions.setLoadSuccess(responseData))
}
```

Fiz essa alteração após perceber que isso seria necessário se algum dia quisermos reescrever o baldr usando esta biblioteca.